### PR TITLE
Feat: update ethereum/tests to v17.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,43 @@
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Rustfmt
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D clippy::all -D clippy::nursery
+      - name: Clippy no_std
+        run: cargo clippy --no-default-features -- -D clippy::all -D clippy::nursery
+      - name: Clippy with features
+        run: cargo clippy --features tracing,create-fixed -- -D clippy::all -D clippy::nursery
+      - name: Clippy with features for evm-jsontests
+        run: cargo clippy -p evm-jsontests --features dump-state -- -D clippy::all -D clippy::nursery
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Build NoStd
+        run: cargo build --no-default-features
+
+      - name: Build for feature (tracing)
+        run: cargo build --features tracing

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Ethereum tests
 
 on:
   push:
@@ -7,43 +7,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  ETHTESTS_VERSION: v14.1
+  ETHTESTS_VERSION: v17.0
   ETHEREUM_SPEC_TESTS_URL: https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/fixtures_pectra-devnet-6.tar.gz
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Rustfmt
-        run: cargo fmt --all -- --check
-
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D clippy::all -D clippy::nursery
-      - name: Clippy no_std
-        run: cargo clippy --no-default-features -- -D clippy::all -D clippy::nursery
-      - name: Clippy with features
-        run: cargo clippy --features tracing,create-fixed -- -D clippy::all -D clippy::nursery
-      - name: Clippy with features for evm-jsontests
-        run: cargo clippy -p evm-jsontests --features dump-state -- -D clippy::all -D clippy::nursery
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-
-      - name: Build
-        run: cargo build --verbose
-
-      - name: Build NoStd
-        run: cargo build --no-default-features
-
-      - name: Build for feature (tracing)
-        run: cargo build --features tracing
-
   unit-tests:
     runs-on: ubuntu-latest
     steps:
@@ -99,8 +66,6 @@ jobs:
           ethtests/GeneralStateTests/ \
           ethtests/LegacyTests/Cancun/GeneralStateTests/ \
           ethereum-spec-tests/fixtures/state_tests/
-          # Temporally disable as EOFv1 not implemented
-          # ethtests/EIPTests/StateTests/
 
       - name: Run Ethereum vm tests
         run: |
@@ -151,8 +116,7 @@ jobs:
               ethtests/GeneralStateTests/ \
               ethtests/LegacyTests/Cancun/GeneralStateTests/ \
               ethereum-spec-tests/fixtures/state_tests/
-              # Temporally disable as EOFv1 not implemented
-              # ethtests/EIPTests/StateTests/
+
             cargo run -r -p evm-jsontests -F enable-slow-tests -- vm -f \
               ethtests/LegacyTests/Constantinople/VMTests/vmArithmeticTest \
               ethtests/LegacyTests/Constantinople/VMTests/vmBitwiseLogicOperation \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-[![Build Status](https://github.com/rust-blockchain/evm/workflows/Rust/badge.svg)](https://github.com/rust-blockchain/evm/actions?query=workflow%3ARust)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](sLICENSE)
+[![Build & Lint Status](https://github.com/rust-blockchain/evm/workflows/Rust/badge.svg)](https://github.com/rust-blockchain/evm/actions?query=workflow%3ARust)
+[![Ethereum tests Status](https://github.com/rust-blockchain/evm/workflows/Rust/badge.svg)](https://github.com/rust-blockchain/evm/actions?query=workflow%3ARust)
+[![Crates.io version](https://img.shields.io/crates/v/aurora-evm.svg?style=flat-square)](https://crates.io/crates/aurora-evm)
+[![Crates.io Total Downloads](https://img.shields.io/crates/d/aurora-evm?style=flat-square&label=crates.io%20downloads)](https://crates.io/crates/aurora-evm)
+
 
 <div align="center">
   <h1>Aurora EVM</h1>
@@ -47,7 +51,7 @@ To get started, add the following dependency to your `Cargo.toml`:
 
 ```toml 
 [dependencies]
-aurora-evm = "1.0"
+aurora-evm = "2.0"
 ```
 
 ## License: [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](sLICENSE)
-[![Build & Lint Status](https://github.com/rust-blockchain/evm/workflows/Rust/badge.svg)](https://github.com/rust-blockchain/evm/actions?query=workflow%3ARust)
-[![Ethereum tests Status](https://github.com/rust-blockchain/evm/workflows/Rust/badge.svg)](https://github.com/rust-blockchain/evm/actions?query=workflow%3ARust)
+[![Build & Lint Status](https://github.com/aurora-is-near/aurora-evm/actions/workflows/lint.yml/badge.svg)](https://github.com/aurora-is-near/aurora-evm/actions/workflows/lint.yml)
+[![Ethereum tests Status](https://github.com/aurora-is-near/aurora-evm/actions/workflows/rust.yml/badge.svg)](https://github.com/aurora-is-near/aurora-evm/actions/workflows/rust.yml)
 [![Crates.io version](https://img.shields.io/crates/v/aurora-evm.svg?style=flat-square)](https://crates.io/crates/aurora-evm)
 [![Crates.io Total Downloads](https://img.shields.io/crates/d/aurora-evm?style=flat-square&label=crates.io%20downloads)](https://crates.io/crates/aurora-evm)
 

--- a/evm-tests/jsontests/src/main.rs
+++ b/evm-tests/jsontests/src/main.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 #[allow(clippy::cognitive_complexity)]
 fn main() -> Result<(), String> {
@@ -239,8 +240,15 @@ fn run_test_for_file(
     let test_suite = serde_json::from_reader::<_, HashMap<String, statetests::Test>>(reader)
         .expect("Parse test cases failed");
 
+    let file_name = Arc::new(file_name.to_path_buf());
     for (name, test) in test_suite {
-        let test_res = statetests::test(verbose_output.clone(), &name, test, spec.clone());
+        let test_res = statetests::test(
+            verbose_output.clone(),
+            &name,
+            test,
+            spec.clone(),
+            file_name.clone(),
+        );
 
         if test_res.failed > 0 {
             if verbose_output.verbose {


### PR DESCRIPTION
## Description

➡️  Updated `ethereum/tests` to [v17.0](https://github.com/ethereum/tests/releases/tag/v17.0)
➡️  Added `file_name` to `assert` messages.
➡️  Changed CI: separated to `lint` and `ethtests`
➡️  Added additional badges to `README.md`