### PR TITLE
Chore: update rust toolchain to v1.86

### DIFF
--- a/evm-tests/ethcore-builtin/src/lib.rs
+++ b/evm-tests/ethcore-builtin/src/lib.rs
@@ -112,7 +112,7 @@ struct ModexpPricer {
 
 impl Pricer for Linear {
     fn cost(&self, input: &[u8]) -> U256 {
-        U256::from(self.base) + U256::from(self.word) * U256::from((input.len() + 31) / 32)
+        U256::from(self.base) + U256::from(self.word) * U256::from(input.len().div_ceil(32))
     }
 }
 

--- a/evm/src/backend/memory.rs
+++ b/evm/src/backend/memory.rs
@@ -92,7 +92,7 @@ impl<'vicinity> MemoryBackend<'vicinity> {
     }
 
     /// Get a mutable reference to the underlying `BTreeMap` storing the state.
-    pub fn state_mut(&mut self) -> &mut BTreeMap<H160, MemoryAccount> {
+    pub const fn state_mut(&mut self) -> &mut BTreeMap<H160, MemoryAccount> {
         &mut self.state
     }
 }
@@ -173,7 +173,7 @@ impl Backend for MemoryBackend<'_> {
     fn is_empty_storage(&self, address: H160) -> bool {
         self.state
             .get(&address)
-            .map_or(true, |v| v.storage.is_empty())
+            .is_none_or(|v| v.storage.is_empty())
     }
 
     fn original_storage(&self, address: H160, index: H256) -> Option<H256> {

--- a/evm/src/core/eval/mod.rs
+++ b/evm/src/core/eval/mod.rs
@@ -51,7 +51,7 @@ fn eval_table<H: InterpreterHandler>(
                 table_elem!($operation, $state, _pc, $definition)
             };
             ($operation:ident, $state:ident, $pc:ident, $definition:expr) => {
-                #[allow(non_snake_case)]
+                #[allow(non_snake_case, clippy::missing_const_for_fn)]
                 fn $operation($state: &mut Machine, _opcode: Opcode, $pc: usize) -> Control {
                     $definition
                 }
@@ -301,7 +301,7 @@ fn eval_table<H: InterpreterHandler>(
                 state.exit(e.clone().into());
                 return Control::Exit(ExitReason::Error(e));
             }
-        };
+        }
         let control = TABLE[op.as_usize()](state, op, pc);
 
         #[cfg(feature = "tracing")]

--- a/evm/src/core/mod.rs
+++ b/evm/src/core/mod.rs
@@ -74,7 +74,7 @@ impl Machine {
         &self.stack
     }
     /// Mutable reference of machine stack.
-    pub fn stack_mut(&mut self) -> &mut Stack {
+    pub const fn stack_mut(&mut self) -> &mut Stack {
         &mut self.stack
     }
     /// Reference of machine memory.
@@ -83,7 +83,7 @@ impl Machine {
         &self.memory
     }
     /// Mutable reference of machine memory.
-    pub fn memory_mut(&mut self) -> &mut Memory {
+    pub const fn memory_mut(&mut self) -> &mut Memory {
         &mut self.memory
     }
     /// Return a reference of the program counter.

--- a/evm/src/executor/stack/executor.rs
+++ b/evm/src/executor/stack/executor.rs
@@ -247,7 +247,7 @@ impl<'config> StackSubstateMetadata<'config> {
         &self.gasometer
     }
 
-    pub fn gasometer_mut(&mut self) -> &mut Gasometer<'config> {
+    pub const fn gasometer_mut(&mut self) -> &mut Gasometer<'config> {
         &mut self.gasometer
     }
 
@@ -445,7 +445,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
         &self.state
     }
 
-    pub fn state_mut(&mut self) -> &mut S {
+    pub const fn state_mut(&mut self) -> &mut S {
         &mut self.state
     }
 
@@ -942,7 +942,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
                 self.state
                     .metadata_mut()
                     .access_addresses([caller, address].iter().copied());
-            };
+            }
 
             self.warm_access_list(access_list);
         }
@@ -1287,7 +1287,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
             Ok(())
         }
 
-        log::debug!(target: "evm", "Create execution using address {}: {:?}", created_address, reason);
+        log::debug!(target: "evm", "Create execution using address {created_address}: {reason:?}");
 
         match reason {
             ExitReason::Succeed(s) => {
@@ -1355,7 +1355,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
         reason: &ExitReason,
         return_data: Vec<u8>,
     ) -> Vec<u8> {
-        log::debug!(target: "evm", "Call execution using address {}: {:?}", code_address, reason);
+        log::debug!(target: "evm", "Call execution using address {code_address}: {reason:?}");
         match reason {
             ExitReason::Succeed(_) => {
                 let _ = self.exit_substate(&StackExitKind::Succeeded);

--- a/evm/src/executor/stack/memory.rs
+++ b/evm/src/executor/stack/memory.rs
@@ -43,11 +43,12 @@ impl<'config> MemoryStackSubstate<'config> {
     }
 
     #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
     pub fn logs(&self) -> &[Log] {
         &self.logs
     }
 
-    pub fn logs_mut(&mut self) -> &mut Vec<Log> {
+    pub const fn logs_mut(&mut self) -> &mut Vec<Log> {
         &mut self.logs
     }
 
@@ -56,7 +57,7 @@ impl<'config> MemoryStackSubstate<'config> {
         &self.metadata
     }
 
-    pub fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
+    pub const fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
         &mut self.metadata
     }
 
@@ -315,9 +316,7 @@ impl<'config> MemoryStackSubstate<'config> {
         if local_is_accessed {
             false
         } else {
-            self.parent
-                .as_ref()
-                .map_or(true, |p| p.recursive_is_cold(f))
+            self.parent.as_ref().is_none_or(|p| p.recursive_is_cold(f))
         }
     }
 

--- a/evm/src/gasometer/mod.rs
+++ b/evm/src/gasometer/mod.rs
@@ -481,7 +481,7 @@ pub const fn init_code_cost(data: &[u8]) -> u64 {
     // As per EIP-3860:
     // > We define initcode_cost(initcode) to equal INITCODE_WORD_COST * ceil(len(initcode) / 32).
     // where INITCODE_WORD_COST is 2.
-    2 * ((data.len() as u64 + 31) / 32)
+    2 * (data.len() as u64).div_ceil(32)
 }
 
 /// Counts the number of addresses and storage keys in the access list

--- a/evm/src/runtime/eval/system.rs
+++ b/evm/src/runtime/eval/system.rs
@@ -167,7 +167,7 @@ pub fn extcodecopy<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H>
     ) {
         Ok(()) => (),
         Err(e) => return Control::Exit(e.into()),
-    };
+    }
 
     Control::Continue
 }
@@ -204,7 +204,7 @@ pub fn returndatacopy<H: Handler>(runtime: &mut Runtime) -> Control<H> {
         .resize_offset(memory_offset, len));
     if data_offset
         .checked_add(len.into())
-        .map_or(true, |l| l > U256::from(runtime.return_data_buffer.len()))
+        .is_none_or(|l| l > U256::from(runtime.return_data_buffer.len()))
     {
         return Control::Exit(ExitError::OutOfOffset.into());
     }
@@ -343,7 +343,7 @@ pub fn mcopy<H: Handler>(runtime: &mut Runtime, _handler: &mut H) -> Control<H> 
     match runtime.machine.memory_mut().copy(src, dst, len) {
         Ok(()) => (),
         Err(e) => return Control::Exit(e.into()),
-    };
+    }
 
     Control::Continue
 }

--- a/evm/src/runtime/interrupt.rs
+++ b/evm/src/runtime/interrupt.rs
@@ -14,7 +14,7 @@ pub struct ResolveCreate<'a> {
 }
 
 impl<'a> ResolveCreate<'a> {
-    pub(crate) fn new(runtime: &'a mut Runtime) -> Self {
+    pub(crate) const fn new(runtime: &'a mut Runtime) -> Self {
         Self { _runtime: runtime }
     }
 }
@@ -25,7 +25,7 @@ pub struct ResolveCall<'a> {
 }
 
 impl<'a> ResolveCall<'a> {
-    pub(crate) fn new(runtime: &'a mut Runtime) -> Self {
+    pub(crate) const fn new(runtime: &'a mut Runtime) -> Self {
         Self { _runtime: runtime }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Description

🚀  Rust toolchain updated to `v1.86`
➡️ Fixed clippy