### PR TITLE
Chore: add execution-spec-tests v4.4.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,8 @@ env:
   CARGO_TERM_COLOR: always
   ETHTESTS_VERSION: v17.0
   ETHEREUM_SPEC_TESTS_URL: https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/fixtures_pectra-devnet-6.tar.gz
-  ETHEREUM_SPEC_TESTS2_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v4.3.0/fixtures_stable.tar.gz
+  ETHEREUM_SPEC_TESTS2_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_stable.tar.gz
+  ETHEREUM_SPEC_TESTS_STATIC_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_static.tar.gz
 
 jobs:
   unit-tests:
@@ -67,10 +68,17 @@ jobs:
           mkdir ethereum-spec-tests2
           tar -xzf ethereum-spec-tests2.tar.gz -C ethereum-spec-tests2
 
+      - name: Download Ethereum spec tests fixtures static
+        run: |
+          curl -L ${{ env.ETHEREUM_SPEC_TESTS_STATIC_URL }} -o ethereum-spec-tests-static.tar.gz
+          mkdir ethereum-spec-tests-static
+          tar -xzf ethereum-spec-tests-static.tar.gz -C ethereum-spec-tests-static
+
       - name: Run Ethereum state tests
         run: |
           cargo run -r -p evm-jsontests -F enable-slow-tests -- state -f \
           ethtests/GeneralStateTests/ \
+          ethereum-spec-tests-static/fixtures/state_tests/ \
           ethtests/LegacyTests/Cancun/GeneralStateTests/ \
           ethereum-spec-tests/fixtures/state_tests/ \
           ethereum-spec-tests2/fixtures/state_tests/
@@ -117,17 +125,25 @@ jobs:
             apt-get update && apt-get install -y curl wget clang llvm
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             export PATH="$PATH:$HOME/.cargo/bin"
+
             curl -L ${{ env.ETHEREUM_SPEC_TESTS_URL }} -o ethereum-spec-tests.tar.gz
             mkdir ethereum-spec-tests
             tar -xzf ethereum-spec-tests.tar.gz -C ethereum-spec-tests
+
             curl -L ${{ env.ETHEREUM_SPEC_TESTS2_URL }} -o ethereum-spec-tests2.tar.gz
             mkdir ethereum-spec-tests2
-            tar -xzf ethereum-spec-tests2.tar.gz -C ethereum-spec-tests2            
+            tar -xzf ethereum-spec-tests2.tar.gz -C ethereum-spec-tests2
+
+            curl -L ${{ env.ETHEREUM_SPEC_TESTS_STATIC_URL }} -o ethereum-spec-tests-static.tar.gz
+            mkdir ethereum-spec-tests-static
+            tar -xzf ethereum-spec-tests-static.tar.gz -C ethereum-spec-tests-static
+
             cargo run -r -p evm-jsontests -F enable-slow-tests -- state -f \
               ethtests/GeneralStateTests/ \
+              ethereum-spec-tests-static/fixtures/state_tests/ \
               ethtests/LegacyTests/Cancun/GeneralStateTests/ \
               ethereum-spec-tests/fixtures/state_tests/ \
-            ethereum-spec-tests2/fixtures/state_tests/
+              ethereum-spec-tests2/fixtures/state_tests/
 
             cargo run -r -p evm-jsontests -F enable-slow-tests -- vm -f \
               ethtests/LegacyTests/Constantinople/VMTests/vmArithmeticTest \


### PR DESCRIPTION
## Description

➡️ Added latest [execution-spec-tests v4.4.0 (Stromovka)](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.4.0)
➡️ Added new rule for CI

### Considerations about `execution-spec-tests` versions

Due to the emergence of a new type of tests under version `fixtures-static-v4.4.0` related to `ethereum/tests` (actually static fixtures contains `GeneralStateTests` replicas), this has caused confusion regarding the test contents. For example, versions `ethereum/tests v17.0` contains different tests count. As a result, it was decided to keep the fixtures for `ethereum/tests` and add new tests in CI separately for `fixtures-static v4.4.0`, and to update future versions for both types of fixtures until the `execution-spec-tests` development team provides final clarification.

🛋️  As a result, the current number of covered tests is **190,762**.