### PR TITLE
 Chore: add execution-spec-tests v4.5.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,8 +9,8 @@ env:
   CARGO_TERM_COLOR: always
   ETHTESTS_VERSION: v17.0
   ETHEREUM_SPEC_TESTS_URL: https://github.com/ethereum/execution-spec-tests/releases/download/pectra-devnet-6%40v1.0.0/fixtures_pectra-devnet-6.tar.gz
-  ETHEREUM_SPEC_TESTS2_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_stable.tar.gz
-  ETHEREUM_SPEC_TESTS_STATIC_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v4.4.0/fixtures_static.tar.gz
+  ETHEREUM_SPEC_TESTS2_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_stable.tar.gz
+  ETHEREUM_SPEC_TESTS_STATIC_URL: https://github.com/ethereum/execution-spec-tests/releases/download/v4.5.0/fixtures_static.tar.gz
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Description

➡️ Added latest [execution-spec-tests v4.5.0 (Hradčany)](https://github.com/ethereum/execution-spec-tests/releases/tag/v4.5.0)


🛋️  As a result, the current number of covered tests is **183,344**.