### PR TITLE
Feat: gas cost refactoring for EXT-opcodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
 edition = "2021"
-version = "2.1.1"
+version = "2.1.2"
 description = "Aurora Ethereum Virtual Machine implementation written in pure Rust"
 categories = ["no-std", "compilers", "cryptography::cryptocurrencies"]
 keywords = ["aurora-evm", "evm", "ethereum", "blockchain", "no_std"]

--- a/evm/src/core/memory.rs
+++ b/evm/src/core/memory.rs
@@ -36,7 +36,9 @@ impl Memory {
 
     /// Get the length of the current memory range.
     #[must_use]
-    pub const fn len(&self) -> usize {
+    // TODO: rust-v1.87 - const fn
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn len(&self) -> usize {
         self.data.len()
     }
 
@@ -48,7 +50,9 @@ impl Memory {
 
     /// Return true if current effective memory range is zero.
     #[must_use]
-    pub const fn is_empty(&self) -> bool {
+    // TODO: rust-v1.87 - const fn
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 

--- a/evm/src/core/stack.rs
+++ b/evm/src/core/stack.rs
@@ -30,14 +30,18 @@ impl Stack {
     /// Stack length.
     #[inline]
     #[must_use]
-    pub const fn len(&self) -> usize {
+    // TODO: rust-v1.87 - const fn
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn len(&self) -> usize {
         self.data.len()
     }
 
     /// Whether the stack is empty.
     #[inline]
     #[must_use]
-    pub const fn is_empty(&self) -> bool {
+    // TODO: rust-v1.87 - const fn
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
 

--- a/evm/src/core/valids.rs
+++ b/evm/src/core/valids.rs
@@ -32,14 +32,18 @@ impl Valids {
     /// code bytes.
     #[inline]
     #[must_use]
-    pub const fn len(&self) -> usize {
+    // TODO: rust-v1.87 - const fn
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Returns true if the valids list is empty
     #[inline]
     #[must_use]
-    pub const fn is_empty(&self) -> bool {
+    // TODO: rust-v1.87 - const fn
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 

--- a/evm/src/gasometer/mod.rs
+++ b/evm/src/gasometer/mod.rs
@@ -1077,29 +1077,27 @@ impl Inner<'_> {
             GasCost::Low => u64::from(consts::G_LOW),
             GasCost::Invalid(opcode) => return Err(ExitError::InvalidCode(opcode)),
 
-            GasCost::ExtCodeSize { target_is_cold } => costs::address_access_cost(
+            GasCost::ExtCodeSize { target_is_cold } => costs::non_delegated_access_cost(
                 target_is_cold,
-                None,
                 self.config.gas_ext_code,
                 self.config,
             ),
             GasCost::ExtCodeCopy {
                 target_is_cold,
                 len,
-            } => costs::extcodecopy_cost(len, target_is_cold, None, self.config)?,
-            GasCost::Balance { target_is_cold } => costs::address_access_cost(
+            } => costs::ext_codecopy_cost(len, target_is_cold, self.config)?,
+            GasCost::ExtCodeHash { target_is_cold } => costs::non_delegated_access_cost(
                 target_is_cold,
-                None,
+                self.config.gas_ext_code_hash,
+                self.config,
+            ),
+
+            GasCost::Balance { target_is_cold } => costs::non_delegated_access_cost(
+                target_is_cold,
                 self.config.gas_balance,
                 self.config,
             ),
             GasCost::BlockHash => u64::from(consts::G_BLOCKHASH),
-            GasCost::ExtCodeHash { target_is_cold } => costs::address_access_cost(
-                target_is_cold,
-                None,
-                self.config.gas_ext_code_hash,
-                self.config,
-            ),
             GasCost::WarmStorageRead => costs::storage_read_warm(self.config),
         })
     }


### PR DESCRIPTION
## Description

➡️ Added clippy allowances for `const fn` for compatibility with `Rust v1.86`, since `aurora-engine` currently supports only `v1.86`.
➡️ Refactored EVM gas handling for cases without delegated gas computation for warm/cold addresses. This affects EXT-* and BALANCE opcodes. Since the gas module was moved to a separate location (from opcode execution), it led to code inconsistency and implicit gas calculation logic. This can _potentially_ cause hard-to-detect bugs due to the unified accessed address logic for both warm and cold accesses.