### PR TITLE
Chore: back to Rust v1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 [workspace.package]
 authors = ["Aurora Labs <hello@aurora.dev>"]
 edition = "2021"
-version = "2.1.2"
+version = "2.1.3"
 description = "Aurora Ethereum Virtual Machine implementation written in pure Rust"
 categories = ["no-std", "compilers", "cryptography::cryptocurrencies"]
 keywords = ["aurora-evm", "evm", "ethereum", "blockchain", "no_std"]

--- a/evm/src/backend/memory.rs
+++ b/evm/src/backend/memory.rs
@@ -92,7 +92,7 @@ impl<'vicinity> MemoryBackend<'vicinity> {
     }
 
     /// Get a mutable reference to the underlying `BTreeMap` storing the state.
-    pub const fn state_mut(&mut self) -> &mut BTreeMap<H160, MemoryAccount> {
+    pub fn state_mut(&mut self) -> &mut BTreeMap<H160, MemoryAccount> {
         &mut self.state
     }
 }
@@ -173,7 +173,7 @@ impl Backend for MemoryBackend<'_> {
     fn is_empty_storage(&self, address: H160) -> bool {
         self.state
             .get(&address)
-            .is_none_or(|v| v.storage.is_empty())
+            .map_or(true, |v| v.storage.is_empty())
     }
 
     fn original_storage(&self, address: H160, index: H256) -> Option<H256> {

--- a/evm/src/core/mod.rs
+++ b/evm/src/core/mod.rs
@@ -74,7 +74,7 @@ impl Machine {
         &self.stack
     }
     /// Mutable reference of machine stack.
-    pub const fn stack_mut(&mut self) -> &mut Stack {
+    pub fn stack_mut(&mut self) -> &mut Stack {
         &mut self.stack
     }
     /// Reference of machine memory.
@@ -83,7 +83,7 @@ impl Machine {
         &self.memory
     }
     /// Mutable reference of machine memory.
-    pub const fn memory_mut(&mut self) -> &mut Memory {
+    pub fn memory_mut(&mut self) -> &mut Memory {
         &mut self.memory
     }
     /// Return a reference of the program counter.

--- a/evm/src/executor/stack/executor.rs
+++ b/evm/src/executor/stack/executor.rs
@@ -247,7 +247,7 @@ impl<'config> StackSubstateMetadata<'config> {
         &self.gasometer
     }
 
-    pub const fn gasometer_mut(&mut self) -> &mut Gasometer<'config> {
+    pub fn gasometer_mut(&mut self) -> &mut Gasometer<'config> {
         &mut self.gasometer
     }
 
@@ -445,7 +445,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
         &self.state
     }
 
-    pub const fn state_mut(&mut self) -> &mut S {
+    pub fn state_mut(&mut self) -> &mut S {
         &mut self.state
     }
 

--- a/evm/src/executor/stack/memory.rs
+++ b/evm/src/executor/stack/memory.rs
@@ -48,7 +48,7 @@ impl<'config> MemoryStackSubstate<'config> {
         &self.logs
     }
 
-    pub const fn logs_mut(&mut self) -> &mut Vec<Log> {
+    pub fn logs_mut(&mut self) -> &mut Vec<Log> {
         &mut self.logs
     }
 
@@ -57,7 +57,7 @@ impl<'config> MemoryStackSubstate<'config> {
         &self.metadata
     }
 
-    pub const fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
+    pub fn metadata_mut(&mut self) -> &mut StackSubstateMetadata<'config> {
         &mut self.metadata
     }
 
@@ -316,7 +316,9 @@ impl<'config> MemoryStackSubstate<'config> {
         if local_is_accessed {
             false
         } else {
-            self.parent.as_ref().is_none_or(|p| p.recursive_is_cold(f))
+            self.parent
+                .as_ref()
+                .map_or(true, |p| p.recursive_is_cold(f))
         }
     }
 

--- a/evm/src/runtime/eval/system.rs
+++ b/evm/src/runtime/eval/system.rs
@@ -204,7 +204,7 @@ pub fn returndatacopy<H: Handler>(runtime: &mut Runtime) -> Control<H> {
         .resize_offset(memory_offset, len));
     if data_offset
         .checked_add(len.into())
-        .is_none_or(|l| l > U256::from(runtime.return_data_buffer.len()))
+        .map_or(true, |l| l > U256::from(runtime.return_data_buffer.len()))
     {
         return Control::Exit(ExitError::OutOfOffset.into());
     }

--- a/evm/src/runtime/interrupt.rs
+++ b/evm/src/runtime/interrupt.rs
@@ -14,7 +14,7 @@ pub struct ResolveCreate<'a> {
 }
 
 impl<'a> ResolveCreate<'a> {
-    pub(crate) const fn new(runtime: &'a mut Runtime) -> Self {
+    pub(crate) fn new(runtime: &'a mut Runtime) -> Self {
         Self { _runtime: runtime }
     }
 }
@@ -25,7 +25,7 @@ pub struct ResolveCall<'a> {
 }
 
 impl<'a> ResolveCall<'a> {
-    pub(crate) const fn new(runtime: &'a mut Runtime) -> Self {
+    pub(crate) fn new(runtime: &'a mut Runtime) -> Self {
         Self { _runtime: runtime }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.81.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated several internal methods to remove the `const` qualifier, improving compatibility with earlier Rust versions.
  * Adjusted logic in storage and buffer checks for improved reliability.

* **Chores**
  * Downgraded the Rust toolchain version from 1.87.0 to 1.81.0.
  * Updated the workspace package version to 2.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->